### PR TITLE
Support for Galactic War AI Overhaul FFAs

### DIFF
--- a/ui/mods/section_of_foreign_intelligence/section_of_foreign_intelligence.js
+++ b/ui/mods/section_of_foreign_intelligence/section_of_foreign_intelligence.js
@@ -31,6 +31,10 @@
       if (primary.minions) {
         commanders = commanders.concat(primary.minions.map(intelligence))
       }
+      // Support for Galatic War AI Overhaul
+      if (primary.foes) {
+        commanders = commanders.concat(primary.foes.map(intelligence))
+      }
     }
     return commanders
   })


### PR DESCRIPTION
The next release of Galactic War AI Overhaul will allow systems to have Commanders from another faction within their own allegiance group i.e. FFAs. This is stored in an array called "foes" under the "ai" object. This update allows Section of Foreign Intelligence reports to include these Commanders.